### PR TITLE
Normalized Culture across all threads

### DIFF
--- a/BuffThread.cs
+++ b/BuffThread.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System.Globalization;
+using System.Threading;
 using StardewValley;
 
 namespace ControlValley
@@ -16,6 +17,8 @@ namespace ControlValley
 
         public void Run()
         {
+            Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
+            
             buff.addBuff();
             Thread.Sleep(duration);
             buff.removeBuff();

--- a/ControlClient.cs
+++ b/ControlClient.cs
@@ -22,6 +22,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading;
@@ -155,6 +156,7 @@ namespace ControlValley
 
         public void NetworkLoop()
         {
+            Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
             while (Running)
             {
                 UI.ShowInfo("Attempting to connect to Crowd Control");
@@ -202,6 +204,7 @@ namespace ControlValley
 
         public void RequestLoop()
         {
+            Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
             while (Running)
             {
                 try

--- a/ModEntry.cs
+++ b/ModEntry.cs
@@ -20,6 +20,7 @@
  * USA
  */
 
+using System.Globalization;
 using System.Threading;
 using StardewModdingAPI;
 using StardewModdingAPI.Events;
@@ -32,6 +33,8 @@ namespace ControlValley
 
         public override void Entry(IModHelper helper)
         {
+            Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
+            
             if (Context.IsMultiplayer)
             {
                 this.Monitor.Log("Crowd Control is unavailable in multiplayer. Skipping mod.", LogLevel.Info);
@@ -44,6 +47,8 @@ namespace ControlValley
 
         private void OnReturnedToTitle(object sender, ReturnedToTitleEventArgs e)
         {
+            Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
+            
             if (client == null) return;
             Helper.Events.GameLoop.Saved -= client.OnSaved;
             Helper.Events.GameLoop.Saving -= client.OnSaving;
@@ -54,6 +59,8 @@ namespace ControlValley
 
         private void OnSaveLoaded(object sender, SaveLoadedEventArgs e)
         {
+            Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
+            
             if (!Context.IsWorldReady || client != null) return;
             client = new ControlClient();
             Helper.Events.GameLoop.Saved += client.OnSaved;


### PR DESCRIPTION
This change adds `Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;` to all threads I could find.

Based on my own before-and-after testing, this appears to fix #15.